### PR TITLE
Optional timezone configuration

### DIFF
--- a/Mage/Console.php
+++ b/Mage/Console.php
@@ -100,6 +100,9 @@ class Console
 
         // Command Option
         $commandName = $config->getArgument(0);
+        
+        // Timezone for logging
+        @date_default_timezone_set($config->general('timezone', 'UTC'));
 
         // Logging
         $showGreetings = true;


### PR DESCRIPTION
- Reads an optional timezone param from general.yml to log with the correct datetime

Signed-off-by: Dani Sancas <lord.sancas@gmail.com>